### PR TITLE
Fix cachyos v3/v4 mirrorlist

### DIFF
--- a/linuxloops
+++ b/linuxloops
@@ -3959,12 +3959,14 @@ set -e
 if [ "${cachyos_version}" == "x86-64-v4" ]; then
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/docker/raw/refs/heads/master/pacman-v4.conf -o /etc/pacman_cachyos.conf
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/CachyOS-PKGBUILDS/raw/refs/heads/master/cachyos-mirrorlist/cachyos-mirrorlist -o /etc/pacman.d/cachyos-mirrorlist
-	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/CachyOS-PKGBUILDS/raw/refs/heads/master/cachyos-v4-mirrorlist/cachyos-v4-mirrorlist -o /etc/pacman.d/cachyos-v4-mirrorlist
+	cp /etc/pacman.d/cachyos-mirrorlist /etc/pacman.d/cachyos-v4-mirrorlist
+	sed -i 's|/\$arch/|/\$arch_v4/|g' /etc/pacman.d/cachyos-v4-mirrorlist
 
 elif [ "${cachyos_version}" == "x86-64-v3" ]; then
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/docker/raw/refs/heads/master/pacman-v3.conf -o /etc/pacman_cachyos.conf
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/CachyOS-PKGBUILDS/raw/refs/heads/master/cachyos-mirrorlist/cachyos-mirrorlist -o /etc/pacman.d/cachyos-mirrorlist
-	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/CachyOS-PKGBUILDS/raw/refs/heads/master/cachyos-v3-mirrorlist/cachyos-v3-mirrorlist -o /etc/pacman.d/cachyos-v3-mirrorlist
+	cp /etc/pacman.d/cachyos-mirrorlist /etc/pacman.d/cachyos-v3-mirrorlist
+	sed -i 's|/\$arch/|/\$arch_v3/|g' /etc/pacman.d/cachyos-v3-mirrorlist
 else
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/docker/raw/refs/heads/master/pacman.conf -o /etc/pacman_cachyos.conf
 	curl --progress-bar --connect-timeout 60 --retry 10 --retry-delay 1 -L -f https://github.com/CachyOS/CachyOS-PKGBUILDS/raw/refs/heads/master/cachyos-mirrorlist/cachyos-mirrorlist -o /etc/pacman.d/cachyos-mirrorlist


### PR DESCRIPTION
Apparently, they updated the code to work this way (commit: https://github.com/CachyOS/CachyOS-PKGBUILDS/commit/6759fdb854fa56cd6456e6f69e866c96b5e5cf49) rather than having seperate mirrorlist files for v3 and v4.

Without this applied, it gives 404 error when x86-64-v3 or x86-64-v4 is selected:

```curl: (22) The requested URL returned error: 404```